### PR TITLE
OGC Services are deprecated

### DIFF
--- a/ServerAuthoring3SelfServe/3.02.FMEServerServices.md
+++ b/ServerAuthoring3SelfServe/3.02.FMEServerServices.md
@@ -41,13 +41,7 @@ Although the concept sounds complicated, a service is a simpler way of communica
 
 FME Server includes the following services:
 
-## *NB: IS THIS SECTION STILL CORRECT? DO WE STILL HAVE OGC SERVICES?*
-
-
 <table>
-<tr><td>OGC Web Feature Service (WFS)</td><td rowspan="2">OGC Services</td></tr>
-<tr><td>OGC Web Feature Service (WFS)</td></tr>
-
 <tr><td>Data Download Service</td><td rowspan="4">Transformation Services</td></tr>
 <tr><td>Data Streaming Service</td></tr>
 <tr><td>Job Submitter Service</td></tr>


### PR DESCRIPTION
I talked to Aaron about this and OGC Services are not supported in the traditional way anymore and should not be included in this table. There is a workaround to bring them back if needed but we'd rather motivate the users to use the new approach to create OGC conform web services and also advertise this in the training manual. Since both, WMS and WFS are published as data streaming service, 3.16 Other Self-Services would be a good place to mention the new OGC method. Here's a PR that shows how this was dealt with in the FME Server Admin Guide: [http://bugzilla/show_bug.cgi?id=67079](http://bugzilla/show_bug.cgi?id=67079)
