### PR TITLE
Rearranged image

### DIFF
--- a/DesktopBasic2Transformation/2.Exercise7.md
+++ b/DesktopBasic2Transformation/2.Exercise7.md
@@ -130,6 +130,8 @@ Also examine the data in the FME Data Inspector to ensure all division polygons 
 
 Place an ExpressionEvaluator transformer after the FeatureMerger - connect it to the FeatureMerger's Merged output port - and open the parameters dialog.
 
+![](./Images/Img2.79.Ex7.ExpressionEvaluatorMathsEditor.png)
+
 Set the New Attribute to Turnout (to match what we have on the destination schema).
 
 In the expression window set the expression to:
@@ -140,7 +142,6 @@ In the expression window set the expression to:
 
 You don't need to type this in - the @Value(Votes) and @Value(Voters) part can be obtained by double-clicking that attribute in the list to the left.
 
-![](./Images/Img2.79.Ex7.ExpressionEvaluatorMathsEditor.png)
 
 
 Click OK to close the dialog. If you wish you can reconnect an Inspector and re-run the translation, to see what the result is.


### PR DESCRIPTION
Based on feedback from 10 people at training - rearranged so that the image that shows how to do it is before the text. Many people asked  information regarding what was listted after the expression (ie, yuo dont need to type this, and the scrrenshot how it was done). So the solution should be moved some lines earlier as shown.