### PR TITLE
Remove reference to List transformer category

### DIFF
--- a/DesktopBasic5Transformers/5.04.ManagingAttributes.md
+++ b/DesktopBasic5Transformers/5.04.ManagingAttributes.md
@@ -66,7 +66,7 @@ myList{2}.myAttribute
 etc.
 </pre>
 
-There are various transformers designed to operate specifically on lists - they can be found in the Lists category of the transformer gallery - and list functionality is built into other transformers (such as the AttributeCreator) too.
+There are various transformers designed to operate specifically on lists and list functionality is built into other transformers (such as the AttributeCreator) too.
 
 ---
 


### PR DESCRIPTION
The List transformer category no longer exists. Removed reference to it.