### PR TITLE
Update Work with Geometry lesson content for FME 2025.2

### DIFF
--- a/2024.2/integrate-spatial-data/Work with Geometry 2024.2/Inspect Geometry Details/index.html
+++ b/2024.2/integrate-spatial-data/Work with Geometry 2024.2/Inspect Geometry Details/index.html
@@ -77,7 +77,7 @@
 <p><img src="images/1737488070748.png" alt="Geometry rraits from an IFC reader" /></p>
 <p>The <a href="https://docs.safe.com/fme/html/FME-Form-Documentation/FME-Transformers/Transformers/traitmerger.htm" target="_blank" rel="noopener">TraitMerger</a> transformer moves the traits from one geometry to another geometry. It can also move the attributes from a feature onto a geometry as traits, or the traits from a geometry onto a feature as attributes. Several related transformers can modify geometry traits (<a href="https://docs.safe.com/fme/html/FME-Form-Documentation/FME-Transformers/Transformers/geometrypropertyextractor.htm" target="_blank" rel="noopener">GeometryPropertyExtractor</a>, <a href="https://docs.safe.com/fme/html/FME-Form-Documentation/FME-Transformers/Transformers/geometrypropertyremover.htm" target="_blank" rel="noopener">GeometryPropertyRemover</a>, <a href="https://docs.safe.com/fme/html/FME-Form-Documentation/FME-Transformers/Transformers/geometrypropertyrenamer.htm" target="_blank" rel="noopener">GeometryPropertyRenamer</a>, and <a href="https://docs.safe.com/fme/html/FME-Form-Documentation/FME-Transformers/Transformers/geometrypropertysetter.htm" target="_blank" rel="noopener">GeometryPropertySetter</a>).</p>
 <h2>Measures</h2>
-<p>Some Geometries can have measures associated with them (also known as "linear referencing" or "dynamic segmentation"). These are an arbitrary number of additional dimensions at each vertex location. These dimensions are named and must have a Real64 type value. A "default measure" is optional and does not need to be named.</p>
+<p>Some Geometries can have measures associated with them (also known as "linear referencing" or "dynamic segmentation"). These are an arbitrary number of additional dimensions at each vertex location. These dimensions are named and must have a Real64 type value. The measure name is shown as <code>&lt;default_measure&gt;</code> unless another name is provided.</p>
 <p><img src="images/1737491918333.png" alt="Measures on a feature" /></p>
 <p>There are a few transformers that work with measures:</p>
 <ul>
@@ -96,10 +96,12 @@
 <p>Amar is working with a new dataset: a GML file representing part of the coastline in the City of Vancouver. He needs to understand its geometry structure. Basic points, lines, and polygons are simple enough, but what is a MultiCurve? He sends the data to Jennifer, a more experienced FME user, and asks her to explain the difference between multi-geometry, multiple geometry, and aggregates.</p>
 <p>She returns a workspace with some transformers and annotations to answer his question and explain more about FME's geometry model.</p>
 <h2>1) Open and Run Starting Workspace</h2>
-<p>Amar opens the <a href="https://s3.amazonaws.com/FMEData/FMEData/Workspaces/IntegrateSpatialData/inspect-geometry-details.fmw" target="_blank" rel="noopener">starting workspace</a> in FME Workbench (2024.2 or later) and runs it to generate feature caches.</p>
+<p>Amar opens the <a href="https://s3.amazonaws.com/FMEData/FMEData/Workspaces/IntegrateSpatialData/inspect-geometry-details.fmw" target="_blank" rel="noopener">starting workspace</a> in FME Workbench (2025.2 or later) and runs it to generate feature caches.</p>
+<p>Before inspecting caches, he confirms the Coastline reader is pointing to <code>C:\FMEData\Data\Boundaries\Coastline.gml</code> so the walkthrough matches the sample data for this lesson.</p>
 <h2>2) Use the Feature Information Window to View Geometry</h2>
 <p>First, he inspects the Coastline reader feature type by clicking the green feature cache icon:</p>
 <p><img src="images/1737759758379.png" alt="Coastlines feature cache" /></p>
+<p><strong>Screenshot update needed (2025.2):</strong> Replace this screenshot if it shows a different dataset (for example, parks). It should show the Coastline reader feature cache from <code>Coastline.gml</code>.</p>
 <p>Then, he looks at the Feature Information Window and expands the Geometry section. This area reports the data's geometry type: MultiCurve:</p>
 <p><img src="images/1737759871771.png" alt="Expanding Geometry to see MultiCurve" /></p>
 <p>He clicks MultiCurve to expand that section and observes the MultiCurve has 72 parts, which are Lines:</p>
@@ -115,16 +117,20 @@
 <h2><img src="images/1737760314636.png" alt="Each feature is a Line" /></h2>
 <h2>4) Inspect Other Geometry Types - Aggregator</h2>
 <p>The Deaggregator can break geometry apart; which transformer can put them back together? The Aggregator.</p>
-<p>Amar inspects the Aggregator's Aggregate port. Contrary to the name of this port, the resulting geometry here is a MultiCurve again. The transformer created a MultiCurve because the default value of the Aggregate Type parameter is Homogeneous Collection (If Possible). With this approach, if FME can make the output geometry into a homogeneous collection without changing the geometry type of any of its parts, then this option will perform the conversion. Because all the geometry received were Lines, FME created a MultiCurve.</p>
-<p>&nbsp;</p>
+<p>Amar inspects the Aggregator's Aggregate port. Even though the port is named Aggregate, the output geometry is a MultiCurve in this step.</p>
+<p>Why? The Aggregator's default Aggregate Type is <strong>Homogeneous Collection (If Possible)</strong>. That setting tells FME to create a Multi* geometry when all input parts are the same base geometry type. Here, all 72 input features are Lines, so the output is a MultiCurve.</p>
+<p>In other words, the port name tells you where to inspect output from the transformer, while the <em>Aggregate Type</em> parameter controls the geometry type that is created.</p>
+<p><strong>Screenshot update needed (2025.2):</strong> Capture the Aggregator parameters dialog with <em>Aggregate Type = Homogeneous Collection (If Possible)</em> and a matching Feature Information Window view showing the output geometry as <em>MultiCurve</em>.</p>
 <p><img src="images/1737760444307.png" alt="MultiCurve output by the Aggregator" width="564" height="679" /></p>
 <p>To create an Aggregate from this MultiCurve, Jennifer sent the Aggregator's Aggregate output port features into&nbsp;<em>another&nbsp;</em>Aggregator, Aggregator_2. This transformer creates an Aggregate with one part: the MultiCurve.</p>
 <p><img src="images/1737760703536.png" alt="An Aggregate with one MultiLine child" /></p>
 <p>Jennifer shows how you can continue nesting features by sending the feature into <em>another&nbsp;</em>Aggregator, Aggregator_3. Now, the feature has an Aggregate geometry with one Aggregate child, which has one MultiCurve child.</p>
 <p><img src="images/1738021212685.png" alt="Further nesting of geometry with the Aggregator" /></p>
 <p>Using transformers like this allows you to define parent-child geometry relationships. The Group By and Aggregation Mode parameters in the Aggregator allow greater control over such nesting.</p>
-<h2>5) Inspect Other Geometry Types - Aggregator with Homogenous Collection</h2>
-<p>To immediately create an Aggregate from the deaggregated features, Jennifer shows that you can set the Aggreator's Aggregate Type parameter to Homogenous Collection. The output of Aggregator_4 shows the results of this decision:</p>
+<h2>5) Inspect Other Geometry Types - Aggregator with Heterogeneous Collection</h2>
+<p>To immediately create an Aggregate from the deaggregated features, Jennifer sets Aggregator_4's <strong>Aggregate Type</strong> to <strong>Heterogeneous Collection</strong>. This forces the output to remain an Aggregate, even when all input parts are Lines.</p>
+<p>This is the key contrast with Step 4: <strong>Homogeneous Collection (If Possible)</strong> produced a MultiCurve, while <strong>Heterogeneous Collection</strong> produces an Aggregate.</p>
+<p><strong>Screenshot update needed (2025.2):</strong> Capture Aggregator_4 parameters with <em>Aggregate Type = Heterogeneous Collection</em>, plus the corresponding Feature Information Window result showing an Aggregate with many Line parts.</p>
 <p><img src="images/1738021288422.png" alt="One Aggregate with many Lines" /></p>
 <h2>6) Inspect Other Geometry Types - Multiple Geometry</h2>
 <p>Next, Amar looks at how Jennifer created a multiple geometry using the MultipleGeometrySetter transformer. This transformer turns the MultiCurve from the source data into a multiple geometry. FME represents the feature as an Aggregate, but the crucial difference can be seen by mousing over the geometry type to view the tooltip, which reports: "IFMEAggregate, Multiple Geometry: 72 Geometries." Now, instead of being an Aggregate with 72 parts (as in the output of the Aggregator_4), the data is an Aggregate composed of 72 distinct geometries:</p>

--- a/2024.2/integrate-spatial-data/Work with Geometry 2024.2/Set Geometry Type/index.html
+++ b/2024.2/integrate-spatial-data/Work with Geometry 2024.2/Set Geometry Type/index.html
@@ -39,14 +39,16 @@
 <h2>Exercise: Set and Filter Geometry</h2>
 <p>Amar is continuing to learn about FME's geometry handling. He is reading a table from a PostGIS database called public.BusinessOwners. It contains information about the location of local businesses.</p>
 <h2>1) Open and Run Starting Workspace</h2>
-<p>Amar opens the <a href="https://s3.amazonaws.com/FMEData/FMEData/Workspaces/IntegrateSpatialData/set-geometry-type.fmw" target="_blank" rel="noopener">starting workspace</a> in FME Workbench (2024.2 or later).</p>
-<p>This workspace requires access to a PostGIS database to work.</p>
+<p>Amar opens the <a href="https://s3.amazonaws.com/FMEData/FMEData/Workspaces/IntegrateSpatialData/set-geometry-type.fmw" target="_blank" rel="noopener">starting workspace</a> in FME Workbench (2025.2 or later).</p>
+<p>This workspace requires access to a PostGIS database connection.</p>
+<p>If you are not in a Safe Software-hosted training environment and do not have this database, you can still complete the lesson by reviewing the provided screenshots and focusing on the GeometryFilter and writer geometry settings.</p>
 <blockquote>
 <p><img class="img mtm" role="presentation" src="images/safe_note.png" alt="Note" /></p>
 <p>If you are taking a Safe Software-hosted training course, this database connection should already exist and you can skip to step #2.</p>
 </blockquote>
 <p>He expands FME Training PostGIS Database [POSTGIS] in the Navigator, double-clicks the Connection parameter, and chooses <strong>Add Database Connection</strong>.</p>
 <p><img src="images/1742933573883.png" alt="Fixing database reference" /></p>
+<p><strong>Screenshot update needed (2025.2):</strong> Verify this image matches the current 2025.2 connection dialog labels and button placement for adding a PostGIS connection.</p>
 <div class="box message info">
 <div class="inner">
 <div class="bd">
@@ -111,7 +113,7 @@
 <p><em>Map tiles &copy;&nbsp;<a href="https://www.stadiamaps.com/" target="_blank" rel="noopener">Stadia Maps</a>, &copy;&nbsp;<a href="https://openmaptiles.org/" target="_blank" rel="noopener">OpenMapTiles</a>, &copy;&nbsp;<a href="https://www.openstreetmap.org/about/" target="_blank" rel="noopener">OpenStreetMap contributors</a>, &copy;&nbsp;<a href="https://academy.safe.com/path/fme-form-basic/connect-to-data/Stamen%20Design" target="_blank" rel="noopener">Stamen Design</a></em></p>
 <blockquote>
 <p><img class="img mtm" role="presentation" src="images/safe_note.png" alt="Note" /></p>
-<p>If these features had more information, like invalid geometry he could repair or attributes that he could use to identify and fix the data, he could keep working on the data from the Null port. However, neither is true, so he'll discard the null geometry features.</p>
+<p>If these features had more information, like invalid geometry he could repair or attributes that he could use to identify and fix the data, he could keep working on the data from the Null port. However, neither is true, so he will filter these null-geometry features out of the translation and continue writing only valid point features.</p>
 </blockquote>
 <h2>Challenge</h2>
 <p>Amar also has a set of address Point features in his workspace in the PostalAddress feature type. He'd like to create MultiPoints from them using the Postalcode attribute to group the Points. What transformer can he use for that? How many MultiPoints does it result in?</p>

--- a/2024.2/integrate-spatial-data/Work with Geometry 2024.2/Transform and Fix Geometry/index.html
+++ b/2024.2/integrate-spatial-data/Work with Geometry 2024.2/Transform and Fix Geometry/index.html
@@ -66,7 +66,7 @@
 <h3 id="h_01HW8X9WTEQB5ZYDA1M2CSMDXC">Part 1: Locating Invalid Geometry Types</h3>
 <p>Follow these steps to learn how to identify contour features that have an invalid geometry type.</p>
 <p><strong>1. Create workspace</strong></p>
-<p>Start FME Workbench (2024.2 or later) and click New to begin with an empty canvas.</p>
+<p>Start FME Workbench (2025.2 or later) and click New to begin with an empty canvas.</p>
 <p>Select Readers &gt; Add Reader from the menubar. In the dialog that opens set the data format to OGC GML (Geography Markup Language).</p>
 <p>Set https://s3.amazonaws.com/FMEData/FMEData/Resources/IntegrateSpatialData/ContoursO8.gml as the source Dataset.</p>
 <p>Click OK to close the dialog and add the reader.</p>


### PR DESCRIPTION
### Motivation
- Bring the Work with Geometry lesson text up to date for FME 2025.2 and remove wording that could confuse learners. 
- Clarify behavioral differences in the Aggregator transformer and make screenshot-maintenance notes to avoid misleading images across versions.

### Description
- Updated three lesson pages: `Inspect Geometry Details/index.html`, `Set Geometry Type/index.html`, and `Transform and Fix Geometry/index.html` to reference `2025.2` and adjust related explanatory text. 
- Clarified measures text to show the default measure name as `<default_measure>`. 
- Rewrote the Aggregator section to explain why the `Aggregate` port can emit a `MultiCurve` (default `Homogeneous Collection (If Possible)`) and changed Step 5 to demonstrate `Heterogeneous Collection` producing an `Aggregate`, adding explicit contrast text. 
- Added structured "Screenshot update needed (2025.2)" notes, a dataset confirmation note for the Coastline example, guidance for users without the training PostGIS environment, and reworded null-geometry handling to describe filtering rather than "discarding".

### Testing
- Ran `git diff --check` to validate patch formatting and whitespace, which completed without errors. 
- Used `rg -n` searches for target phrases (version strings, aggregator/collection terms, screenshot notes, and measure text) to confirm all intended replacements were applied successfully. 
- Reviewed diffs of the three modified files to confirm scope and content consistency; changes were committed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6994beb2002483268ebfa83235b37823)