### PR TITLE
Add Jira CSV export ingestion and normalization workflow

### DIFF
--- a/.agents/skills/training-updater/SKILL.md
+++ b/.agents/skills/training-updater/SKILL.md
@@ -5,7 +5,7 @@ Use this skill for end-to-end training content updates driven by a change ledger
 ## Workflow
 1. Build/refresh lesson manifest from HTML lessons.
 2. Build docs change ledger (Jira snapshot or changelog input).
-3. Generate update queue from manifest + ledger.
+3. Generate update queue from manifest + ledger + explicit update scope (from/to version + courses).
 4. Execute one lesson at a time: generate update spec first, then apply minimal edits.
 
 ## Commands
@@ -20,7 +20,7 @@ Use this skill for end-to-end training content updates driven by a change ledger
 - Jira snapshot to ledger:
   - `python tools/jira_to_change_ledger.py --in inputs/jira_snapshot.json --out artifacts/docs_change_ledger.jsonl`
 - Queue generation:
-  - `python tools/generate_update_queue.py --manifest artifacts/lesson_manifest.json --ledger artifacts/docs_change_ledger.jsonl --out artifacts/update_queue.json`
+  - `python tools/generate_update_queue.py --manifest artifacts/lesson_manifest.json --ledger artifacts/docs_change_ledger.jsonl --scope-file inputs/update_scope.json --out artifacts/update_queue.json`
 - Apply one lesson update:
   - `python tools/apply_update_queue.py --queue artifacts/update_queue.json --manifest artifacts/lesson_manifest.json --ledger artifacts/docs_change_ledger.jsonl --lesson-id <lesson_id>`
 

--- a/.agents/skills/training-updater/SKILL.md
+++ b/.agents/skills/training-updater/SKILL.md
@@ -1,0 +1,30 @@
+# training-updater
+
+Use this skill for end-to-end training content updates driven by a change ledger.
+
+## Workflow
+1. Build/refresh lesson manifest from HTML lessons.
+2. Build docs change ledger (Jira snapshot or changelog input).
+3. Generate update queue from manifest + ledger.
+4. Execute one lesson at a time: generate update spec first, then apply minimal edits.
+
+## Commands
+- Build manifest:
+  - `python tools/build_lesson_manifest.py --config tools/config.json --out artifacts/lesson_manifest.json`
+- Jira snapshot pull:
+  - `python tools/pull_from_jira.py --jql "project = DOCS" --out inputs/jira_snapshot.json`
+- Normalize Jira export (CSV/JSON) to internal snapshot:
+  - `python tools/ingest_jira_export.py --in inputs/jira_export.csv --out inputs/jira_snapshot.json`
+- Generate changelog from Jira snapshot:
+  - `python tools/generate_changelog_from_jira.py --in inputs/jira_snapshot.json --out inputs/changelog_generated.md`
+- Jira snapshot to ledger:
+  - `python tools/jira_to_change_ledger.py --in inputs/jira_snapshot.json --out artifacts/docs_change_ledger.jsonl`
+- Queue generation:
+  - `python tools/generate_update_queue.py --manifest artifacts/lesson_manifest.json --ledger artifacts/docs_change_ledger.jsonl --out artifacts/update_queue.json`
+- Apply one lesson update:
+  - `python tools/apply_update_queue.py --queue artifacts/update_queue.json --manifest artifacts/lesson_manifest.json --ledger artifacts/docs_change_ledger.jsonl --lesson-id <lesson_id>`
+
+## Guardrails
+- Never bulk-edit without writing `artifacts/update_specs/<lesson_id>.json` first.
+- If evidence is weak, add TODO markers instead of inventing UI details.
+- Only flag screenshot likely-stale when tied to specific ledger evidence.

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,13 @@
+[defaults]
+# Keep command behavior conservative for planning/introspection commands.
+planning_mode = "read-only"
+execution_mode = "workspace-write"
+
+[paths]
+repo_config = "tools/config.json"
+schemas_dir = ".codex/schemas"
+artifacts_dir = "artifacts"
+
+[safety]
+require_per_lesson_spec = true
+avoid_bulk_edits = true

--- a/.codex/schemas/change_ledger_record.schema.json
+++ b/.codex/schemas/change_ledger_record.schema.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Change Ledger Record",
+  "type": "object",
+  "required": [
+    "change_id",
+    "source",
+    "user_visible_summary",
+    "change_type",
+    "ui_text_changes",
+    "evidence",
+    "docs_relevance_score",
+    "docs_relevance_reason"
+  ],
+  "properties": {
+    "change_id": {"type": "string"},
+    "source": {"type": "string"},
+    "release": {"type": ["string", "null"]},
+    "feature_area": {"type": ["string", "null"]},
+    "user_visible_summary": {"type": "string"},
+    "change_type": {
+      "type": "string",
+      "enum": ["label rename", "workflow change", "new field", "navigation change", "permissions", "other"]
+    },
+    "ui_text_changes": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["old_label", "new_label", "context"],
+        "properties": {
+          "old_label": {"type": ["string", "null"]},
+          "new_label": {"type": ["string", "null"]},
+          "context": {"type": "string"}
+        }
+      }
+    },
+    "workflow_before": {"type": ["string", "null"]},
+    "workflow_after": {"type": ["string", "null"]},
+    "evidence": {
+      "type": "object",
+      "required": ["jira_key", "links", "fields_used"],
+      "properties": {
+        "jira_key": {"type": ["string", "null"]},
+        "links": {"type": "array", "items": {"type": "string"}},
+        "fields_used": {"type": "array", "items": {"type": "string"}}
+      }
+    },
+    "docs_relevance_score": {"type": "number", "minimum": 0, "maximum": 1},
+    "docs_relevance_reason": {"type": "string"}
+  }
+}

--- a/.codex/schemas/lesson_manifest.schema.json
+++ b/.codex/schemas/lesson_manifest.schema.json
@@ -2,23 +2,124 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Lesson Manifest",
   "type": "object",
-  "required": ["schema_version", "lesson_count", "lessons"],
+  "required": [
+    "schema_version",
+    "lesson_count",
+    "scope",
+    "lessons"
+  ],
   "properties": {
-    "schema_version": {"type": "string"},
-    "lesson_count": {"type": "integer", "minimum": 0},
+    "schema_version": {
+      "type": "string"
+    },
+    "lesson_count": {
+      "type": "integer",
+      "minimum": 0
+    },
     "lessons": {
       "type": "array",
       "items": {
         "type": "object",
-        "required": ["lesson_id", "lesson_path", "title", "headings", "exercise_steps", "ui_strings", "image_references"],
+        "required": [
+          "lesson_id",
+          "lesson_path",
+          "title",
+          "headings",
+          "exercise_steps",
+          "ui_strings",
+          "image_references",
+          "metadata"
+        ],
         "properties": {
-          "lesson_id": {"type": "string"},
-          "lesson_path": {"type": "string"},
-          "title": {"type": "string"},
-          "headings": {"type": "array", "items": {"type": "string"}},
-          "exercise_steps": {"type": "array", "items": {"type": "object"}},
-          "ui_strings": {"type": "array", "items": {"type": "string"}},
-          "image_references": {"type": "array", "items": {"type": "object"}}
+          "lesson_id": {
+            "type": "string"
+          },
+          "lesson_path": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "headings": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "exercise_steps": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          },
+          "ui_strings": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "image_references": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          },
+          "metadata": {
+            "type": "object",
+            "required": [
+              "version",
+              "product",
+              "course",
+              "lesson",
+              "course_path"
+            ],
+            "properties": {
+              "version": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "product": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "course": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "lesson": {
+                "type": "string"
+              },
+              "course_path": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "scope": {
+      "type": "object",
+      "properties": {
+        "versions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "courses": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       }
     }

--- a/.codex/schemas/lesson_manifest.schema.json
+++ b/.codex/schemas/lesson_manifest.schema.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Lesson Manifest",
+  "type": "object",
+  "required": ["schema_version", "lesson_count", "lessons"],
+  "properties": {
+    "schema_version": {"type": "string"},
+    "lesson_count": {"type": "integer", "minimum": 0},
+    "lessons": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["lesson_id", "lesson_path", "title", "headings", "exercise_steps", "ui_strings", "image_references"],
+        "properties": {
+          "lesson_id": {"type": "string"},
+          "lesson_path": {"type": "string"},
+          "title": {"type": "string"},
+          "headings": {"type": "array", "items": {"type": "string"}},
+          "exercise_steps": {"type": "array", "items": {"type": "object"}},
+          "ui_strings": {"type": "array", "items": {"type": "string"}},
+          "image_references": {"type": "array", "items": {"type": "object"}}
+        }
+      }
+    }
+  }
+}

--- a/.codex/schemas/update_queue.schema.json
+++ b/.codex/schemas/update_queue.schema.json
@@ -2,23 +2,92 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Update Queue",
   "type": "object",
-  "required": ["schema_version", "task_count", "tasks"],
+  "required": [
+    "schema_version",
+    "task_count",
+    "tasks"
+  ],
   "properties": {
-    "schema_version": {"type": "string"},
-    "task_count": {"type": "integer", "minimum": 0},
+    "schema_version": {
+      "type": "string"
+    },
+    "task_count": {
+      "type": "integer",
+      "minimum": 0
+    },
     "tasks": {
       "type": "array",
       "items": {
         "type": "object",
-        "required": ["task_id", "change_id", "lesson_id", "lesson_path", "confidence", "required_update_types"],
+        "required": [
+          "task_id",
+          "change_id",
+          "lesson_id",
+          "lesson_path",
+          "confidence",
+          "required_update_types"
+        ],
         "properties": {
-          "task_id": {"type": "string"},
-          "change_id": {"type": "string"},
-          "lesson_id": {"type": "string"},
-          "lesson_path": {"type": "string"},
-          "confidence": {"type": "number", "minimum": 0, "maximum": 1},
-          "required_update_types": {"type": "array", "items": {"type": "string"}},
-          "likely_stale_screenshots": {"type": "array", "items": {"type": "string"}}
+          "task_id": {
+            "type": "string"
+          },
+          "change_id": {
+            "type": "string"
+          },
+          "lesson_id": {
+            "type": "string"
+          },
+          "lesson_path": {
+            "type": "string"
+          },
+          "confidence": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 1
+          },
+          "required_update_types": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "likely_stale_screenshots": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "scope": {
+      "type": "object",
+      "properties": {
+        "from_version": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "to_version": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "courses": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "scoped_lesson_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "total_manifest_lessons": {
+          "type": "integer",
+          "minimum": 0
         }
       }
     }

--- a/.codex/schemas/update_queue.schema.json
+++ b/.codex/schemas/update_queue.schema.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Update Queue",
+  "type": "object",
+  "required": ["schema_version", "task_count", "tasks"],
+  "properties": {
+    "schema_version": {"type": "string"},
+    "task_count": {"type": "integer", "minimum": 0},
+    "tasks": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["task_id", "change_id", "lesson_id", "lesson_path", "confidence", "required_update_types"],
+        "properties": {
+          "task_id": {"type": "string"},
+          "change_id": {"type": "string"},
+          "lesson_id": {"type": "string"},
+          "lesson_path": {"type": "string"},
+          "confidence": {"type": "number", "minimum": 0, "maximum": 1},
+          "required_update_types": {"type": "array", "items": {"type": "string"}},
+          "likely_stale_screenshots": {"type": "array", "items": {"type": "string"}}
+        }
+      }
+    }
+  }
+}

--- a/.codex/schemas/update_spec.schema.json
+++ b/.codex/schemas/update_spec.schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Update Spec",
+  "type": "object",
+  "required": ["schema_version", "lesson_id", "lesson_path", "task_id", "change_id", "generated_at", "edits"],
+  "properties": {
+    "schema_version": {"type": "string"},
+    "lesson_id": {"type": "string"},
+    "lesson_path": {"type": "string"},
+    "task_id": {"type": "string"},
+    "change_id": {"type": "string"},
+    "generated_at": {"type": "string"},
+    "edits": {"type": "array", "items": {"type": "object"}, "minItems": 1},
+    "notes": {"type": "array", "items": {"type": "string"}}
+  }
+}

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Jira connection (required for live pull)
+JIRA_BASE_URL=https://your-company.atlassian.net
+JIRA_USER_EMAIL=you@example.com
+JIRA_API_TOKEN=replace_me
+# Optional alternative token variable name
+JIRA_PAT=
+# Optional: choose 2 or 3 (defaults to auto, preferring 3)
+JIRA_API_VERSION=auto

--- a/.github/codex/prompts/apply_one.md
+++ b/.github/codex/prompts/apply_one.md
@@ -1,0 +1,9 @@
+# Apply One Lesson Update Task
+
+Given one queue item:
+1. Read the queue task, matching lesson manifest entry, and matching change ledger record.
+2. Produce `artifacts/update_specs/<lesson_id>.json` first (must conform to `.codex/schemas/update_spec.schema.json`).
+3. Apply only the edits in the spec to the lesson HTML file.
+4. Keep diffs minimal and reviewable.
+5. If evidence is insufficient, add a TODO marker and cite missing evidence.
+6. Never bulk-edit multiple lessons in a single pass without per-lesson specs.

--- a/.github/codex/prompts/plan_queue.md
+++ b/.github/codex/prompts/plan_queue.md
@@ -5,10 +5,11 @@ You are generating `artifacts/update_queue.json`.
 Inputs:
 - `artifacts/lesson_manifest.json`
 - `artifacts/docs_change_ledger.jsonl`
+- optional scope: `inputs/update_scope.json` (`from_version`, `to_version`, `courses[]`)
 - Schema: `.codex/schemas/update_queue.schema.json`
 
 Requirements:
-1. Map each change ledger record to one or more lessons with confidence score in [0,1].
+1. Apply scope first (target courses + target version), then map each change ledger record to one or more in-scope lessons with confidence score in [0,1].
 2. Set `required_update_types` from:
    - `text edits`
    - `exercise step edits`

--- a/.github/codex/prompts/plan_queue.md
+++ b/.github/codex/prompts/plan_queue.md
@@ -1,0 +1,18 @@
+# Plan Update Queue
+
+You are generating `artifacts/update_queue.json`.
+
+Inputs:
+- `artifacts/lesson_manifest.json`
+- `artifacts/docs_change_ledger.jsonl`
+- Schema: `.codex/schemas/update_queue.schema.json`
+
+Requirements:
+1. Map each change ledger record to one or more lessons with confidence score in [0,1].
+2. Set `required_update_types` from:
+   - `text edits`
+   - `exercise step edits`
+   - `screenshot updates`
+3. For screenshot tasks, only include `likely_stale_screenshots` when there is direct evidence from change type or label/workflow changes.
+4. Output deterministic ordering by descending confidence then task_id.
+5. Do not invent UI details.

--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,20 @@ $RECYCLE.BIN/
 # Windows shortcuts
 *.lnk
 *.icloud
+
+# Local secrets
+.env
+.env.local
+*.secret
+
+# Jira snapshots (may contain sensitive data)
+inputs/jira_snapshot.json
+inputs/jira_snapshot_*.json
+
+# Generated automation artifacts
+artifacts/
+inputs/changelog_generated.md
+
+# Python cache
+__pycache__/
+*.pyc

--- a/2021.0/fme-form-basic/Work with Multiple Data Models Using Lists 2021.0/Exercise_ Create Lists Using Transformers/index.html
+++ b/2021.0/fme-form-basic/Work with Multiple Data Models Using Lists 2021.0/Exercise_ Create Lists Using Transformers/index.html
@@ -23,7 +23,7 @@
 <h2 id="1-open-fme-workbench">1) Open FME Workbench</h2>
 <p>Open the&nbsp;<a href="https://s3.amazonaws.com/FMEData/FMEData/Workspaces/AdvancedDataTransformation/park_trees_start.fmwt" target="_blank" rel="noreferrer noopener">starting workspace</a>&nbsp;in FME Workbench (2021.0 or later). The workspace is set up so you can inspect the source data on the first run.</p>
 <h2 id="2-run-the-workspace-and-inspect-the-data">2) Run the Workspace and Inspect the Data</h2>
-<p>Run the workspace and view the data in Visual Preview or the Data Inspector. Note how some parks contain multiple point features. For example, China Creek Park North contains two coincident trees, as shown in the Table View:</p>
+<p>Run the workspace and view the data in Visual Preview or the Feature Viewer. Note how some parks contain multiple point features. For example, China Creek Park North contains two coincident trees, as shown in the Table View:</p>
 <p><img class="image image-block image-center" src="https://s3-us-west-2.amazonaws.com/safemytrailhead/modules/work-with-multiple-data-models-using-lists/exercise-create-lists-using-transformers/images/1644277215826.png" alt="Viewing the two trees of China Creek Park in Visual Preview" /></p>
 <p>For the next steps, we won&rsquo;t need to inspect the source data anymore, so right-click the pink bookmark titled&nbsp;<em>Initial Data Inspection&nbsp;</em>and click&nbsp;<em>Disable All Objects in Bookmark.</em>&nbsp;Right-click the data inspector output called&nbsp;<em>Result&nbsp;</em>and enable it<em>.</em></p>
 <h2 id="3-set-point-on-area-overlayer-parameters-merge-attributes">3) Set PointOnAreaOverlayer Parameters: Merge Attributes</h2>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,25 @@
+# Agent Working Rules for FMETraining
+
+## Scope
+These rules apply to the entire repository.
+
+## Style and coding rules
+- Prefer Python standard library over third-party dependencies.
+- Keep scripts deterministic: sorted inputs, stable output ordering, and explicit UTF-8 file handling.
+- Keep functions small and testable; avoid hidden global state.
+- Do not wrap imports in try/catch blocks.
+
+## Step formatting and update artifacts
+- Exercise steps should be extracted as ordered records with step number, heading, and supporting text.
+- Change-ledger records must be small-grained (one user-visible change per record).
+- Queue tasks must identify one target lesson per task with a confidence score and explicit update types.
+
+## Screenshot conventions
+- Never claim a screenshot is updated unless a new image artifact is present.
+- Mark screenshots as `likely_stale` only when evidence exists (e.g., label rename/workflow change touching that lesson).
+
+## Definition of done
+- Schemas exist for manifest, change-ledger record, queue, and update spec.
+- Scripts support dry-run where relevant and fail with clear errors on invalid input.
+- Demo pipeline can run from the provided sample Jira snapshot without live Jira access.
+- Output artifacts are written under `artifacts/` or `inputs/` as documented.

--- a/docs-automation/README.md
+++ b/docs-automation/README.md
@@ -2,16 +2,33 @@
 
 This folder documents the repo-local automation pipeline for lesson updates.
 
+## 0) Define update scope (recommended)
+
+To avoid huge cross-version queues, define exactly what this update round should touch:
+
+- `from_version`: archived source context (for operator intent/history)
+- `to_version`: only this version's lessons are eligible for edits
+- `courses`: course name/path patterns to include
+
+Example:
+
+```bash
+cp inputs/update_scope.example.json inputs/update_scope.json
+```
+
 ## 1) Build the lesson manifest
 
 ```bash
 python tools/build_lesson_manifest.py --config tools/config.json --out artifacts/lesson_manifest.json
 ```
 
-Optional subset run for fast demos:
+Optional scoped manifest build:
 
 ```bash
-python tools/build_lesson_manifest.py --config tools/config.json --limit 3 --out artifacts/lesson_manifest_demo.json
+python tools/build_lesson_manifest.py \
+  --versions 2024.1,2025.0 \
+  --courses "Connect Automations with Job Orchestration" \
+  --out artifacts/lesson_manifest_scoped.json
 ```
 
 ## 2) Pull from Jira (live)
@@ -34,7 +51,7 @@ python tools/pull_from_jira.py \
   --out inputs/jira_snapshot.json
 ```
 
-Dry-run (resolves JQL without fetching):
+Dry-run:
 
 ```bash
 python tools/pull_from_jira.py --jql "project = DOCS" --release "2026.1" --dry-run
@@ -42,19 +59,9 @@ python tools/pull_from_jira.py --jql "project = DOCS" --release "2026.1" --dry-r
 
 ## 2a) Normalize Jira export input (CSV or JSON)
 
-If your team provides a Jira CSV export instead of API access, normalize it into the internal snapshot format first:
-
 ```bash
 python tools/ingest_jira_export.py --in inputs/jira_export.csv --out inputs/jira_snapshot.json
 ```
-
-You can also normalize an existing JSON export/snapshot:
-
-```bash
-python tools/ingest_jira_export.py --in inputs/jira_snapshot.json --out inputs/jira_snapshot.json
-```
-
-The field mapping used for CSV ingestion is configurable in `tools/jira_field_map.json`.
 
 ## 3) Generate deterministic docs changelog from Jira snapshot
 
@@ -64,36 +71,35 @@ python tools/generate_changelog_from_jira.py --in inputs/jira_snapshot.json --ou
 
 ## 4) Build docs Change Ledger
 
-From Jira snapshot (small-grained records):
-
 ```bash
 python tools/jira_to_change_ledger.py --in inputs/jira_snapshot.json --out artifacts/docs_change_ledger.jsonl
 ```
 
-Generic loader (markdown or Jira CSV/JSON exports):
+## 5) Generate update queue (scoped)
 
-```bash
-python tools/load_change_ledger.py --type markdown --in inputs/changelog_generated.md --out artifacts/docs_change_ledger.jsonl
-```
-
-## 5) Generate update queue
+Using a scope file:
 
 ```bash
 python tools/generate_update_queue.py \
   --manifest artifacts/lesson_manifest.json \
   --ledger artifacts/docs_change_ledger.jsonl \
+  --scope-file inputs/update_scope.json \
   --out artifacts/update_queue.json
 ```
 
-Codex prompt-driven option:
+Or explicit CLI scope:
 
 ```bash
-codex exec .github/codex/prompts/plan_queue.md
+python tools/generate_update_queue.py \
+  --manifest artifacts/lesson_manifest.json \
+  --ledger artifacts/docs_change_ledger.jsonl \
+  --from-version 2024.0 \
+  --to-version 2025.0 \
+  --courses "*Connect Automations with Job Orchestration 2025.0,*Build Versatile Automations 2025.0" \
+  --out artifacts/update_queue.json
 ```
 
 ## 6) Apply updates one lesson at a time
-
-Single lesson/task batch (writes per-lesson spec first):
 
 ```bash
 python tools/apply_update_queue.py \
@@ -103,28 +109,14 @@ python tools/apply_update_queue.py \
   --limit 1
 ```
 
-Dry-run:
-
-```bash
-python tools/apply_update_queue.py --dry-run --limit 1
-```
-
-Codex prompt-driven option:
-
-```bash
-codex exec .github/codex/prompts/apply_one.md
-```
-
 ## 7) Demo mode without Jira access
-
-Use the sanitized sample snapshot:
 
 ```bash
 python tools/ingest_jira_export.py --in inputs/sample_jira_export.csv --out inputs/jira_snapshot.json
 python tools/generate_changelog_from_jira.py --in inputs/jira_snapshot.json --out inputs/changelog_generated.md
 python tools/jira_to_change_ledger.py --in inputs/jira_snapshot.json --out artifacts/docs_change_ledger.jsonl
-python tools/build_lesson_manifest.py --limit 3 --out artifacts/lesson_manifest_demo.json
-python tools/generate_update_queue.py --manifest artifacts/lesson_manifest_demo.json --ledger artifacts/docs_change_ledger.jsonl --out artifacts/update_queue.json
+python tools/build_lesson_manifest.py --versions 2024.1 --courses "Connect Automations with Job Orchestration 2024.1" --out artifacts/lesson_manifest_demo.json
+python tools/generate_update_queue.py --manifest artifacts/lesson_manifest_demo.json --ledger artifacts/docs_change_ledger.jsonl --from-version 2023.0 --to-version 2024.1 --courses "*Connect Automations with Job Orchestration 2024.1" --out artifacts/update_queue.json
 python tools/apply_update_queue.py --manifest artifacts/lesson_manifest_demo.json --queue artifacts/update_queue.json --ledger artifacts/docs_change_ledger.jsonl --limit 1
 ```
 

--- a/docs-automation/README.md
+++ b/docs-automation/README.md
@@ -1,0 +1,135 @@
+# Training Update Automation
+
+This folder documents the repo-local automation pipeline for lesson updates.
+
+## 1) Build the lesson manifest
+
+```bash
+python tools/build_lesson_manifest.py --config tools/config.json --out artifacts/lesson_manifest.json
+```
+
+Optional subset run for fast demos:
+
+```bash
+python tools/build_lesson_manifest.py --config tools/config.json --limit 3 --out artifacts/lesson_manifest_demo.json
+```
+
+## 2) Pull from Jira (live)
+
+Set environment variables (see `.env.example`):
+
+- `JIRA_BASE_URL`
+- `JIRA_USER_EMAIL` (or username)
+- `JIRA_API_TOKEN` (or `JIRA_PAT`)
+- `JIRA_API_VERSION` (`auto`, `2`, or `3`)
+
+Example with JQL:
+
+```bash
+python tools/pull_from_jira.py \
+  --jql "project = DOCS AND labels = academy AND statusCategory = Done" \
+  --since "2026-01-01" \
+  --release "2026.1" \
+  --max-issues 200 \
+  --out inputs/jira_snapshot.json
+```
+
+Dry-run (resolves JQL without fetching):
+
+```bash
+python tools/pull_from_jira.py --jql "project = DOCS" --release "2026.1" --dry-run
+```
+
+## 2a) Normalize Jira export input (CSV or JSON)
+
+If your team provides a Jira CSV export instead of API access, normalize it into the internal snapshot format first:
+
+```bash
+python tools/ingest_jira_export.py --in inputs/jira_export.csv --out inputs/jira_snapshot.json
+```
+
+You can also normalize an existing JSON export/snapshot:
+
+```bash
+python tools/ingest_jira_export.py --in inputs/jira_snapshot.json --out inputs/jira_snapshot.json
+```
+
+The field mapping used for CSV ingestion is configurable in `tools/jira_field_map.json`.
+
+## 3) Generate deterministic docs changelog from Jira snapshot
+
+```bash
+python tools/generate_changelog_from_jira.py --in inputs/jira_snapshot.json --out inputs/changelog_generated.md
+```
+
+## 4) Build docs Change Ledger
+
+From Jira snapshot (small-grained records):
+
+```bash
+python tools/jira_to_change_ledger.py --in inputs/jira_snapshot.json --out artifacts/docs_change_ledger.jsonl
+```
+
+Generic loader (markdown or Jira CSV/JSON exports):
+
+```bash
+python tools/load_change_ledger.py --type markdown --in inputs/changelog_generated.md --out artifacts/docs_change_ledger.jsonl
+```
+
+## 5) Generate update queue
+
+```bash
+python tools/generate_update_queue.py \
+  --manifest artifacts/lesson_manifest.json \
+  --ledger artifacts/docs_change_ledger.jsonl \
+  --out artifacts/update_queue.json
+```
+
+Codex prompt-driven option:
+
+```bash
+codex exec .github/codex/prompts/plan_queue.md
+```
+
+## 6) Apply updates one lesson at a time
+
+Single lesson/task batch (writes per-lesson spec first):
+
+```bash
+python tools/apply_update_queue.py \
+  --queue artifacts/update_queue.json \
+  --manifest artifacts/lesson_manifest.json \
+  --ledger artifacts/docs_change_ledger.jsonl \
+  --limit 1
+```
+
+Dry-run:
+
+```bash
+python tools/apply_update_queue.py --dry-run --limit 1
+```
+
+Codex prompt-driven option:
+
+```bash
+codex exec .github/codex/prompts/apply_one.md
+```
+
+## 7) Demo mode without Jira access
+
+Use the sanitized sample snapshot:
+
+```bash
+python tools/ingest_jira_export.py --in inputs/sample_jira_export.csv --out inputs/jira_snapshot.json
+python tools/generate_changelog_from_jira.py --in inputs/jira_snapshot.json --out inputs/changelog_generated.md
+python tools/jira_to_change_ledger.py --in inputs/jira_snapshot.json --out artifacts/docs_change_ledger.jsonl
+python tools/build_lesson_manifest.py --limit 3 --out artifacts/lesson_manifest_demo.json
+python tools/generate_update_queue.py --manifest artifacts/lesson_manifest_demo.json --ledger artifacts/docs_change_ledger.jsonl --out artifacts/update_queue.json
+python tools/apply_update_queue.py --manifest artifacts/lesson_manifest_demo.json --queue artifacts/update_queue.json --ledger artifacts/docs_change_ledger.jsonl --limit 1
+```
+
+## Privacy and sensitive data handling
+
+- Raw Jira snapshots can contain sensitive details.
+- Keep live snapshots in `inputs/` for reproducibility, but sanitize before sharing.
+- Prefer default Jira pull fields and only opt-in to comments/attachments when necessary.

--- a/inputs/sample_jira_export.csv
+++ b/inputs/sample_jira_export.csv
@@ -1,0 +1,4 @@
+Issue key,Summary,Description,Issue Type,Epic Link,Component/s,Fix Version/s,Labels,Status,Created,Updated
+DOCS-101,"Rename 'Data Inspector' to 'Feature Viewer' in Workbench help text","Rename 'Data Inspector' to 'Feature Viewer' in dialogs and menu text.",Story,DOCS-100,"FME Form UI","2026.1","academy,ui",Done,2026-01-08,2026-01-10
+DOCS-102,"Automation editor adds a confirmation dialog before disabling triggers","Users now confirm before disabling a trigger. Workflow changed for automation maintenance.",Bug,DOCS-100,"FME Flow Automations","2026.1","academy,automation",Done,2026-01-09,2026-01-11
+DOCS-103,"Add role-based visibility note for resource connections","Permissions update: non-admin roles cannot view all connection details.",Task,,Security,"2026.1","academy,security",Done,2026-01-10,2026-01-12

--- a/inputs/sample_jira_snapshot.json
+++ b/inputs/sample_jira_snapshot.json
@@ -1,0 +1,42 @@
+{
+  "generated_at": "2026-01-15T00:00:00Z",
+  "source": {
+    "jira_base_url": "https://example.atlassian.net",
+    "jql": "project = DOCS AND fixVersion = '2026.1'",
+    "api_version": "3",
+    "fields": ["summary", "issuetype", "components", "fixVersions", "description"],
+    "max_issues": 100
+  },
+  "issues": [
+    {
+      "key": "DOCS-101",
+      "fields": {
+        "summary": "Rename 'Data Inspector' to 'Feature Viewer' in Workbench help text",
+        "issuetype": {"name": "Story"},
+        "components": [{"name": "FME Form UI"}],
+        "fixVersions": [{"name": "2026.1"}],
+        "description": "Rename 'Data Inspector' to 'Feature Viewer' in dialogs and menu text."
+      }
+    },
+    {
+      "key": "DOCS-102",
+      "fields": {
+        "summary": "Automation editor adds a confirmation dialog before disabling triggers",
+        "issuetype": {"name": "Bug"},
+        "components": [{"name": "FME Flow Automations"}],
+        "fixVersions": [{"name": "2026.1"}],
+        "description": "Users now confirm before disabling a trigger. Workflow changed for automation maintenance."
+      }
+    },
+    {
+      "key": "DOCS-103",
+      "fields": {
+        "summary": "Add role-based visibility note for resource connections",
+        "issuetype": {"name": "Task"},
+        "components": [{"name": "Security"}],
+        "fixVersions": [{"name": "2026.1"}],
+        "description": "Permissions update: non-admin roles cannot view all connection details."
+      }
+    }
+  ]
+}

--- a/inputs/update_scope.example.json
+++ b/inputs/update_scope.example.json
@@ -1,0 +1,8 @@
+{
+  "from_version": "2024.0",
+  "to_version": "2025.0",
+  "courses": [
+    "*/fme-flow-authoring/Connect Automations with Job Orchestration 2025.0",
+    "*/fme-flow-authoring/Build Versatile Automations 2025.0"
+  ]
+}

--- a/tools/apply_update_queue.py
+++ b/tools/apply_update_queue.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from common import dump_json, load_json, load_jsonl
+
+
+def build_lookup(items: list[dict[str, Any]], key: str) -> dict[str, dict[str, Any]]:
+    return {i[key]: i for i in items}
+
+
+def build_spec(task: dict[str, Any], lesson: dict[str, Any], change: dict[str, Any]) -> dict[str, Any]:
+    replacements = []
+    for ui in change.get("ui_text_changes", []):
+        if ui.get("old_label") and ui.get("new_label"):
+            replacements.append(
+                {
+                    "action": "replace_text",
+                    "old_text": ui["old_label"],
+                    "new_text": ui["new_label"],
+                    "evidence": change["change_id"],
+                }
+            )
+
+    if not replacements:
+        replacements.append(
+            {
+                "action": "insert_todo_marker",
+                "marker": f"<!-- TODO(training-update): verify change {change['change_id']} - missing concrete UI labels -->",
+                "evidence": change["change_id"],
+            }
+        )
+
+    return {
+        "schema_version": "1.0",
+        "lesson_id": lesson["lesson_id"],
+        "lesson_path": lesson["lesson_path"],
+        "task_id": task["task_id"],
+        "change_id": change["change_id"],
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "edits": replacements,
+        "notes": [
+            "Spec generated before applying edits.",
+            "If no deterministic replacement exists, TODO marker is inserted.",
+        ],
+    }
+
+
+def apply_spec_to_html(spec: dict[str, Any], dry_run: bool = False) -> tuple[int, bool]:
+    html_path = Path(spec["lesson_path"])
+    original = html_path.read_text(encoding="utf-8", errors="ignore")
+    updated = original
+    changes = 0
+
+    for edit in spec.get("edits", []):
+        if edit["action"] == "replace_text":
+            old = edit["old_text"]
+            new = edit["new_text"]
+            if old in updated:
+                count = updated.count(old)
+                updated = updated.replace(old, new)
+                changes += count
+        elif edit["action"] == "insert_todo_marker":
+            marker = edit["marker"]
+            if marker not in updated:
+                updated = marker + "\n" + updated
+                changes += 1
+
+    changed = updated != original
+    if changed and not dry_run:
+        html_path.write_text(updated, encoding="utf-8")
+    return changes, changed
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--queue", default="artifacts/update_queue.json")
+    ap.add_argument("--manifest", default="artifacts/lesson_manifest.json")
+    ap.add_argument("--ledger", default="artifacts/docs_change_ledger.jsonl")
+    ap.add_argument("--lesson-id")
+    ap.add_argument("--limit", type=int, default=1)
+    ap.add_argument("--spec-dir", default="artifacts/update_specs")
+    ap.add_argument("--dry-run", action="store_true")
+    args = ap.parse_args()
+
+    queue = load_json(args.queue)
+    manifest = load_json(args.manifest)
+    ledger = load_jsonl(args.ledger)
+
+    lesson_by_id = build_lookup(manifest.get("lessons", []), "lesson_id")
+    change_by_id = build_lookup(ledger, "change_id")
+
+    tasks = queue.get("tasks", [])
+    if args.lesson_id:
+        tasks = [t for t in tasks if t.get("lesson_id") == args.lesson_id]
+    tasks = tasks[: args.limit]
+
+    spec_dir = Path(args.spec_dir)
+    spec_dir.mkdir(parents=True, exist_ok=True)
+
+    for task in tasks:
+        lesson = lesson_by_id[task["lesson_id"]]
+        change = change_by_id[task["change_id"]]
+        spec = build_spec(task, lesson, change)
+        spec_path = spec_dir / f"{lesson['lesson_id']}.json"
+        dump_json(spec_path, spec)
+        changes, changed = apply_spec_to_html(spec, dry_run=args.dry_run)
+        state = "DRY-RUN" if args.dry_run else ("CHANGED" if changed else "NO-CHANGE")
+        print(f"{state}: {task['lesson_id']} (edits_applied={changes}) spec={spec_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/build_lesson_manifest.py
+++ b/tools/build_lesson_manifest.py
@@ -13,6 +13,7 @@ from common import dump_json, load_json, slugify
 
 STEP_HEADING_RE = re.compile(r"^\s*(\d+)[\)\.:\-]\s*(.+)$")
 UI_TOKEN_RE = re.compile(r"\b([A-Z][A-Za-z0-9]*(?:\s+[A-Z][A-Za-z0-9]*){0,3})\b")
+VERSION_RE = re.compile(r"^\d{4}\.\d+$")
 
 
 class LessonHTMLParser(HTMLParser):
@@ -24,8 +25,6 @@ class LessonHTMLParser(HTMLParser):
         self.headings: list[str] = []
         self.paragraphs: list[str] = []
         self.images: list[dict[str, Any]] = []
-        self.current_step_num: int | None = None
-        self.current_step_heading: str | None = None
         self.steps: list[dict[str, Any]] = []
 
     def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
@@ -55,10 +54,8 @@ class LessonHTMLParser(HTMLParser):
                     self.title = txt
                 m = STEP_HEADING_RE.match(txt)
                 if m:
-                    self.current_step_num = int(m.group(1))
-                    self.current_step_heading = m.group(2).strip()
                     self.steps.append(
-                        {"step_number": self.current_step_num, "heading": self.current_step_heading, "text": []}
+                        {"step_number": int(m.group(1)), "heading": m.group(2).strip(), "text": []}
                     )
             self.in_heading = None
             self.current_text = []
@@ -97,10 +94,24 @@ def extract_ui_strings(headings: list[str], paragraphs: list[str]) -> list[str]:
     return sorted(candidates)[:100]
 
 
+def extract_path_metadata(path: Path) -> dict[str, Any]:
+    parts = path.as_posix().split("/")
+    lesson_dir = parts[-2] if len(parts) >= 2 else path.parent.name
+    version = parts[0] if parts and VERSION_RE.match(parts[0]) else None
+    product = parts[1] if len(parts) > 1 else None
+    course = parts[2] if len(parts) > 2 else None
+    return {
+        "version": version,
+        "product": product,
+        "course": course,
+        "lesson": lesson_dir,
+        "course_path": "/".join(parts[:3]) if len(parts) > 2 else None,
+    }
+
+
 def build_manifest_record(path: Path) -> dict[str, Any]:
     parser = LessonHTMLParser()
-    text = path.read_text(encoding="utf-8", errors="ignore")
-    parser.feed(text)
+    parser.feed(path.read_text(encoding="utf-8", errors="ignore"))
     parser.finalize_steps()
 
     image_refs = []
@@ -116,6 +127,7 @@ def build_manifest_record(path: Path) -> dict[str, Any]:
         )
 
     title = parser.title or path.parent.name
+    metadata = extract_path_metadata(path)
     return {
         "lesson_id": slugify(path.parent.as_posix()),
         "lesson_path": path.as_posix(),
@@ -124,7 +136,27 @@ def build_manifest_record(path: Path) -> dict[str, Any]:
         "exercise_steps": parser.steps,
         "ui_strings": extract_ui_strings(parser.headings, parser.paragraphs),
         "image_references": image_refs,
+        "metadata": metadata,
     }
+
+
+def parse_csv_arg(value: str | None) -> list[str]:
+    if not value:
+        return []
+    return [v.strip() for v in value.split(",") if v.strip()]
+
+
+def matches_scope(path: Path, versions: list[str], courses: list[str]) -> bool:
+    p = path.as_posix()
+    if versions:
+        parts = p.split("/")
+        p_version = parts[0] if parts else ""
+        if p_version not in versions:
+            return False
+    if courses:
+        if not any(c in p for c in courses):
+            return False
+    return True
 
 
 def validate_manifest(doc: dict[str, Any]) -> None:
@@ -137,20 +169,40 @@ def main() -> None:
     ap.add_argument("--config", default="tools/config.json")
     ap.add_argument("--out", default="artifacts/lesson_manifest.json")
     ap.add_argument("--limit", type=int)
+    ap.add_argument("--versions", help="Comma-separated versions to include, e.g. 2024.0,2025.0")
+    ap.add_argument("--courses", help="Comma-separated path fragments for course filtering")
     ap.add_argument("--dry-run", action="store_true")
     args = ap.parse_args()
 
     config = load_json(args.config)
     lessons = discover_lessons(config)
+    versions = parse_csv_arg(args.versions)
+    courses = parse_csv_arg(args.courses)
+    if versions or courses:
+        lessons = [p for p in lessons if matches_scope(p, versions, courses)]
     if args.limit:
         lessons = lessons[: args.limit]
 
     records = [build_manifest_record(p) for p in lessons]
-    out_doc = {"schema_version": "1.0", "lesson_count": len(records), "lessons": records}
+    out_doc = {
+        "schema_version": "1.1",
+        "lesson_count": len(records),
+        "scope": {"versions": versions, "courses": courses},
+        "lessons": records,
+    }
     validate_manifest(out_doc)
 
     if args.dry_run:
-        print(json.dumps({"lessons_found": len(lessons), "sample": [r["lesson_path"] for r in records[:3]]}, indent=2))
+        print(
+            json.dumps(
+                {
+                    "lessons_found": len(lessons),
+                    "scope": out_doc["scope"],
+                    "sample": [r["lesson_path"] for r in records[:3]],
+                },
+                indent=2,
+            )
+        )
         return
 
     dump_json(args.out, out_doc)

--- a/tools/build_lesson_manifest.py
+++ b/tools/build_lesson_manifest.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+import re
+from html.parser import HTMLParser
+from pathlib import Path
+from typing import Any
+
+from common import dump_json, load_json, slugify
+
+STEP_HEADING_RE = re.compile(r"^\s*(\d+)[\)\.:\-]\s*(.+)$")
+UI_TOKEN_RE = re.compile(r"\b([A-Z][A-Za-z0-9]*(?:\s+[A-Z][A-Za-z0-9]*){0,3})\b")
+
+
+class LessonHTMLParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.in_heading: str | None = None
+        self.current_text: list[str] = []
+        self.title: str | None = None
+        self.headings: list[str] = []
+        self.paragraphs: list[str] = []
+        self.images: list[dict[str, Any]] = []
+        self.current_step_num: int | None = None
+        self.current_step_heading: str | None = None
+        self.steps: list[dict[str, Any]] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        attrs_dict = {k: v for k, v in attrs}
+        if tag in {"h1", "h2", "h3", "h4"}:
+            self.in_heading = tag
+            self.current_text = []
+        elif tag == "img":
+            src = attrs_dict.get("src") or ""
+            alt = attrs_dict.get("alt")
+            self.images.append({"src": src, "filename": Path(src).name if src else None, "alt": alt})
+
+    def handle_data(self, data: str) -> None:
+        if self.in_heading:
+            self.current_text.append(data)
+        else:
+            text = data.strip()
+            if text:
+                self.paragraphs.append(text)
+
+    def handle_endtag(self, tag: str) -> None:
+        if self.in_heading == tag:
+            txt = " ".join(t.strip() for t in self.current_text).strip()
+            if txt:
+                self.headings.append(txt)
+                if not self.title:
+                    self.title = txt
+                m = STEP_HEADING_RE.match(txt)
+                if m:
+                    self.current_step_num = int(m.group(1))
+                    self.current_step_heading = m.group(2).strip()
+                    self.steps.append(
+                        {"step_number": self.current_step_num, "heading": self.current_step_heading, "text": []}
+                    )
+            self.in_heading = None
+            self.current_text = []
+
+    def finalize_steps(self) -> None:
+        idx = -1
+        for p in self.paragraphs:
+            if STEP_HEADING_RE.match(p):
+                continue
+            if idx + 1 < len(self.steps):
+                self.steps[idx + 1]["text"].append(p)
+                if len(self.steps[idx + 1]["text"]) >= 3:
+                    idx += 1
+
+
+def discover_lessons(config: dict[str, Any]) -> list[Path]:
+    matches: list[Path] = []
+    glob_pattern = config.get("lesson_glob", "**/index.html")
+    excludes = config.get("exclude_paths", [])
+    for root in config.get("lesson_roots", ["."]):
+        for p in Path(root).glob(glob_pattern):
+            p_norm = p.as_posix()
+            if any(fnmatch.fnmatch(p_norm, ex) for ex in excludes):
+                continue
+            if p.is_file():
+                matches.append(p)
+    return sorted(set(matches))
+
+
+def extract_ui_strings(headings: list[str], paragraphs: list[str]) -> list[str]:
+    candidates: set[str] = set()
+    for block in headings + paragraphs[:80]:
+        for m in UI_TOKEN_RE.findall(block):
+            if len(m) > 2 and any(c.isupper() for c in m):
+                candidates.add(m.strip())
+    return sorted(candidates)[:100]
+
+
+def build_manifest_record(path: Path) -> dict[str, Any]:
+    parser = LessonHTMLParser()
+    text = path.read_text(encoding="utf-8", errors="ignore")
+    parser.feed(text)
+    parser.finalize_steps()
+
+    image_refs = []
+    for idx, img in enumerate(parser.images):
+        nearby_caption = parser.paragraphs[idx] if idx < len(parser.paragraphs) else None
+        image_refs.append(
+            {
+                "filename": img.get("filename"),
+                "src": img.get("src"),
+                "caption": nearby_caption,
+                "step_number": parser.steps[idx]["step_number"] if idx < len(parser.steps) else None,
+            }
+        )
+
+    title = parser.title or path.parent.name
+    return {
+        "lesson_id": slugify(path.parent.as_posix()),
+        "lesson_path": path.as_posix(),
+        "title": title,
+        "headings": parser.headings,
+        "exercise_steps": parser.steps,
+        "ui_strings": extract_ui_strings(parser.headings, parser.paragraphs),
+        "image_references": image_refs,
+    }
+
+
+def validate_manifest(doc: dict[str, Any]) -> None:
+    if "lessons" not in doc or not isinstance(doc["lessons"], list):
+        raise ValueError("manifest must include lessons[]")
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--config", default="tools/config.json")
+    ap.add_argument("--out", default="artifacts/lesson_manifest.json")
+    ap.add_argument("--limit", type=int)
+    ap.add_argument("--dry-run", action="store_true")
+    args = ap.parse_args()
+
+    config = load_json(args.config)
+    lessons = discover_lessons(config)
+    if args.limit:
+        lessons = lessons[: args.limit]
+
+    records = [build_manifest_record(p) for p in lessons]
+    out_doc = {"schema_version": "1.0", "lesson_count": len(records), "lessons": records}
+    validate_manifest(out_doc)
+
+    if args.dry_run:
+        print(json.dumps({"lessons_found": len(lessons), "sample": [r["lesson_path"] for r in records[:3]]}, indent=2))
+        return
+
+    dump_json(args.out, out_doc)
+    print(f"Wrote manifest with {len(records)} lessons to {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/common.py
+++ b/tools/common.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+def load_json(path: str | Path) -> Any:
+    with Path(path).open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def dump_json(path: str | Path, data: Any) -> None:
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    with p.open("w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2, ensure_ascii=False)
+        f.write("\n")
+
+
+def slugify(value: str) -> str:
+    clean = "".join(c.lower() if c.isalnum() else "-" for c in value)
+    while "--" in clean:
+        clean = clean.replace("--", "-")
+    return clean.strip("-") or "lesson"
+
+
+def load_jsonl(path: str | Path) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    with Path(path).open("r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            out.append(json.loads(line))
+    return out
+
+
+def write_jsonl(path: str | Path, records: list[dict[str, Any]]) -> None:
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    with p.open("w", encoding="utf-8") as f:
+        for rec in records:
+            f.write(json.dumps(rec, ensure_ascii=False, sort_keys=True))
+            f.write("\n")

--- a/tools/config.json
+++ b/tools/config.json
@@ -1,0 +1,12 @@
+{
+  "lesson_roots": ["."],
+  "lesson_glob": "**/index.html",
+  "exclude_paths": [".git/**", "artifacts/**", "inputs/**", "docs-automation/**"],
+  "image_dir_names": ["images"],
+  "default_artifacts": {
+    "lesson_manifest": "artifacts/lesson_manifest.json",
+    "change_ledger": "artifacts/docs_change_ledger.jsonl",
+    "update_queue": "artifacts/update_queue.json",
+    "update_specs_dir": "artifacts/update_specs"
+  }
+}

--- a/tools/config.json
+++ b/tools/config.json
@@ -1,12 +1,22 @@
 {
-  "lesson_roots": ["."],
+  "lesson_roots": [
+    "."
+  ],
   "lesson_glob": "**/index.html",
-  "exclude_paths": [".git/**", "artifacts/**", "inputs/**", "docs-automation/**"],
-  "image_dir_names": ["images"],
+  "exclude_paths": [
+    ".git/**",
+    "artifacts/**",
+    "inputs/**",
+    "docs-automation/**"
+  ],
+  "image_dir_names": [
+    "images"
+  ],
   "default_artifacts": {
     "lesson_manifest": "artifacts/lesson_manifest.json",
     "change_ledger": "artifacts/docs_change_ledger.jsonl",
     "update_queue": "artifacts/update_queue.json",
-    "update_specs_dir": "artifacts/update_specs"
+    "update_specs_dir": "artifacts/update_specs",
+    "update_scope": "inputs/update_scope.json"
   }
 }

--- a/tools/generate_changelog_from_jira.py
+++ b/tools/generate_changelog_from_jira.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+from common import load_json
+
+
+def get_release(fields: dict[str, Any]) -> str:
+    versions = fields.get("fixVersions") or []
+    if versions:
+        return versions[0].get("name") or "Unreleased"
+    return "Unreleased"
+
+
+def guess_user_visible_change(summary: str) -> str:
+    s = summary.lower()
+    if "rename" in s or "label" in s:
+        return "[inferred] UI label text changed."
+    if "workflow" in s or "step" in s:
+        return "[inferred] User workflow/steps changed."
+    if "permission" in s or "role" in s:
+        return "[inferred] User permissions/visibility changed."
+    return "[inferred] User-facing behavior changed; confirm details in Jira issue body."
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--in", dest="infile", default="inputs/jira_snapshot.json")
+    ap.add_argument("--out", default="inputs/changelog_generated.md")
+    args = ap.parse_args()
+
+    snapshot = load_json(args.infile)
+    issues = snapshot.get("issues", [])
+
+    grouped: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for issue in sorted(issues, key=lambda i: i.get("key", "")):
+        grouped[get_release(issue.get("fields", {}))].append(issue)
+
+    lines = ["# Generated Docs Changelog", "", "_Deterministic output from Jira snapshot; inferred text is marked._", ""]
+    for release in sorted(grouped):
+        lines.append(f"## Release: {release}")
+        lines.append("")
+        for issue in grouped[release]:
+            fields = issue.get("fields", {})
+            key = issue.get("key")
+            summary = fields.get("summary", "")
+            issue_type = (fields.get("issuetype") or {}).get("name", "Unknown")
+            guess = guess_user_visible_change(summary)
+            lines.append(f"- **{key}** ({issue_type}): {summary}")
+            lines.append(f"  - User-visible change guess: {guess}")
+        lines.append("")
+
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
+    print(f"Wrote changelog to {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/generate_update_queue.py
+++ b/tools/generate_update_queue.py
@@ -2,10 +2,14 @@
 from __future__ import annotations
 
 import argparse
-from pathlib import Path
+import fnmatch
+import json
+import re
 from typing import Any
 
 from common import dump_json, load_json, load_jsonl
+
+VERSION_RE = re.compile(r"^\d{4}\.\d+$")
 
 
 def lesson_text_blob(lesson: dict[str, Any]) -> str:
@@ -42,6 +46,55 @@ def required_update_types(change: dict[str, Any], confidence: float) -> list[str
     return sorted(set(out))
 
 
+def parse_scope_file(path: str | None) -> dict[str, Any]:
+    if not path:
+        return {}
+    return load_json(path)
+
+
+def infer_metadata(lesson: dict[str, Any]) -> dict[str, Any]:
+    meta = lesson.get("metadata") or {}
+    if meta.get("version") and meta.get("course"):
+        return meta
+    p = lesson.get("lesson_path", "")
+    parts = p.split("/")
+    return {
+        "version": parts[0] if parts and VERSION_RE.match(parts[0]) else None,
+        "course": parts[2] if len(parts) > 2 else None,
+        "course_path": "/".join(parts[:3]) if len(parts) > 2 else None,
+    }
+
+
+def normalize_list(value: str | None) -> list[str]:
+    if not value:
+        return []
+    return [x.strip() for x in value.split(",") if x.strip()]
+
+
+def filter_lessons(
+    lessons: list[dict[str, Any]],
+    from_version: str | None,
+    to_version: str | None,
+    courses: list[str],
+) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for lesson in lessons:
+        meta = infer_metadata(lesson)
+        version = meta.get("version")
+        course_path = meta.get("course_path") or ""
+        course_name = meta.get("course") or ""
+
+        # We only update target-version lessons; from_version is included as run metadata.
+        if to_version and version != to_version:
+            continue
+
+        if courses:
+            if not any(fnmatch.fnmatch(course_path, pat) or fnmatch.fnmatch(course_name, pat) or pat in course_path for pat in courses):
+                continue
+        out.append(lesson)
+    return out
+
+
 def validate_queue(queue: dict[str, Any]) -> None:
     if not isinstance(queue.get("tasks"), list):
         raise ValueError("update_queue.tasks must be a list")
@@ -52,6 +105,10 @@ def main() -> None:
     ap.add_argument("--manifest", default="artifacts/lesson_manifest.json")
     ap.add_argument("--ledger", default="artifacts/docs_change_ledger.jsonl")
     ap.add_argument("--out", default="artifacts/update_queue.json")
+    ap.add_argument("--from-version", help="Archived source version context, e.g. 2024.0")
+    ap.add_argument("--to-version", help="Target version to update, e.g. 2025.0")
+    ap.add_argument("--courses", help="Comma-separated course names/patterns or path fragments")
+    ap.add_argument("--scope-file", help="JSON file containing from_version, to_version, courses[]")
     ap.add_argument("--min-confidence", type=float, default=0.25)
     ap.add_argument("--dry-run", action="store_true")
     args = ap.parse_args()
@@ -60,33 +117,52 @@ def main() -> None:
     ledger = load_jsonl(args.ledger)
     lessons = manifest.get("lessons", [])
 
+    scope_file = parse_scope_file(args.scope_file)
+    from_version = args.from_version or scope_file.get("from_version")
+    to_version = args.to_version or scope_file.get("to_version")
+    courses = normalize_list(args.courses) or scope_file.get("courses", [])
+
+    scoped_lessons = filter_lessons(lessons, from_version, to_version, courses)
+
     tasks = []
     for change in ledger:
-        for lesson in lessons:
+        for lesson in scoped_lessons:
             confidence = score_lesson_change(lesson, change)
             if confidence < args.min_confidence:
                 continue
+            update_types = required_update_types(change, confidence)
             task = {
                 "task_id": f"{change['change_id']}::{lesson['lesson_id']}",
                 "change_id": change["change_id"],
                 "lesson_id": lesson["lesson_id"],
                 "lesson_path": lesson["lesson_path"],
                 "confidence": round(confidence, 3),
-                "required_update_types": required_update_types(change, confidence),
+                "required_update_types": update_types,
                 "likely_stale_screenshots": [
                     i["filename"]
                     for i in lesson.get("image_references", [])
-                    if i.get("filename") and "screenshot updates" in required_update_types(change, confidence)
+                    if i.get("filename") and "screenshot updates" in update_types
                 ],
             }
             tasks.append(task)
 
     tasks.sort(key=lambda t: (-t["confidence"], t["task_id"]))
-    queue = {"schema_version": "1.0", "task_count": len(tasks), "tasks": tasks}
+    queue = {
+        "schema_version": "1.1",
+        "task_count": len(tasks),
+        "scope": {
+            "from_version": from_version,
+            "to_version": to_version,
+            "courses": courses,
+            "scoped_lesson_count": len(scoped_lessons),
+            "total_manifest_lessons": len(lessons),
+        },
+        "tasks": tasks,
+    }
     validate_queue(queue)
 
     if args.dry_run:
-        print({"task_count": len(tasks), "sample": tasks[:3]})
+        print(json.dumps({"scope": queue["scope"], "task_count": len(tasks), "sample": tasks[:3]}, indent=2))
         return
 
     dump_json(args.out, queue)

--- a/tools/generate_update_queue.py
+++ b/tools/generate_update_queue.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Any
+
+from common import dump_json, load_json, load_jsonl
+
+
+def lesson_text_blob(lesson: dict[str, Any]) -> str:
+    parts = [lesson.get("title", "")]
+    parts.extend(lesson.get("headings", []))
+    parts.extend(lesson.get("ui_strings", []))
+    return "\n".join(parts).lower()
+
+
+def score_lesson_change(lesson: dict[str, Any], change: dict[str, Any]) -> float:
+    score = 0.1
+    blob = lesson_text_blob(lesson)
+    summary = (change.get("user_visible_summary") or "").lower()
+    for token in summary.split():
+        if len(token) > 4 and token in blob:
+            score += 0.08
+    for ui in change.get("ui_text_changes", []):
+        old = (ui.get("old_label") or "").lower()
+        new = (ui.get("new_label") or "").lower()
+        if old and old in blob:
+            score += 0.4
+        if new and new in blob:
+            score += 0.2
+    return max(0.0, min(1.0, score))
+
+
+def required_update_types(change: dict[str, Any], confidence: float) -> list[str]:
+    ctype = change.get("change_type")
+    out = ["text edits"]
+    if ctype == "workflow change":
+        out.append("exercise step edits")
+    if ctype in {"label rename", "navigation change", "workflow change"} and confidence >= 0.35:
+        out.append("screenshot updates")
+    return sorted(set(out))
+
+
+def validate_queue(queue: dict[str, Any]) -> None:
+    if not isinstance(queue.get("tasks"), list):
+        raise ValueError("update_queue.tasks must be a list")
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--manifest", default="artifacts/lesson_manifest.json")
+    ap.add_argument("--ledger", default="artifacts/docs_change_ledger.jsonl")
+    ap.add_argument("--out", default="artifacts/update_queue.json")
+    ap.add_argument("--min-confidence", type=float, default=0.25)
+    ap.add_argument("--dry-run", action="store_true")
+    args = ap.parse_args()
+
+    manifest = load_json(args.manifest)
+    ledger = load_jsonl(args.ledger)
+    lessons = manifest.get("lessons", [])
+
+    tasks = []
+    for change in ledger:
+        for lesson in lessons:
+            confidence = score_lesson_change(lesson, change)
+            if confidence < args.min_confidence:
+                continue
+            task = {
+                "task_id": f"{change['change_id']}::{lesson['lesson_id']}",
+                "change_id": change["change_id"],
+                "lesson_id": lesson["lesson_id"],
+                "lesson_path": lesson["lesson_path"],
+                "confidence": round(confidence, 3),
+                "required_update_types": required_update_types(change, confidence),
+                "likely_stale_screenshots": [
+                    i["filename"]
+                    for i in lesson.get("image_references", [])
+                    if i.get("filename") and "screenshot updates" in required_update_types(change, confidence)
+                ],
+            }
+            tasks.append(task)
+
+    tasks.sort(key=lambda t: (-t["confidence"], t["task_id"]))
+    queue = {"schema_version": "1.0", "task_count": len(tasks), "tasks": tasks}
+    validate_queue(queue)
+
+    if args.dry_run:
+        print({"task_count": len(tasks), "sample": tasks[:3]})
+        return
+
+    dump_json(args.out, queue)
+    print(f"Wrote {len(tasks)} update tasks to {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/ingest_jira_export.py
+++ b/tools/ingest_jira_export.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import csv
+import datetime as dt
+import json
+from pathlib import Path
+from typing import Any
+
+from common import dump_json, load_json
+
+
+def load_field_map(path: str) -> dict[str, Any]:
+    return load_json(path)
+
+
+def split_multi(value: str, delimiters: list[str]) -> list[str]:
+    if not value:
+        return []
+    vals = [value]
+    for delim in delimiters:
+        next_vals: list[str] = []
+        for item in vals:
+            next_vals.extend(item.split(delim))
+        vals = next_vals
+    return [v.strip() for v in vals if v.strip()]
+
+
+def find_column(row: dict[str, str], aliases: list[str]) -> str | None:
+    for alias in aliases:
+        if alias in row:
+            return alias
+    lowered = {k.lower(): k for k in row.keys()}
+    for alias in aliases:
+        key = lowered.get(alias.lower())
+        if key:
+            return key
+    return None
+
+
+def normalize_issue_from_row(
+    row: dict[str, str],
+    field_map: dict[str, Any],
+    resolved_columns: dict[str, str | None],
+) -> dict[str, Any]:
+    canonical = field_map["canonical_fields"]
+    delims = field_map.get("multi_value_delimiters", [",", ";"])
+
+    def get_value(name: str) -> str:
+        col = resolved_columns.get(name)
+        if not col:
+            return ""
+        return (row.get(col) or "").strip()
+
+    key = get_value("key")
+    summary = get_value("summary")
+    description = get_value("description")
+    issue_type = get_value("issue_type")
+    parent = get_value("parent")
+    components = split_multi(get_value("components"), delims)
+    fix_versions = split_multi(get_value("fixVersions"), delims)
+    labels = split_multi(get_value("labels"), delims)
+    status = get_value("status")
+    created = get_value("created")
+    updated = get_value("updated")
+
+    return {
+        "key": key,
+        "fields": {
+            "summary": summary,
+            "description": description,
+            "issuetype": {"name": issue_type} if issue_type else None,
+            "parent": {"key": parent} if parent else None,
+            "components": [{"name": c} for c in components],
+            "fixVersions": [{"name": v} for v in fix_versions],
+            "labels": labels,
+            "status": {"name": status} if status else None,
+            "created": created or None,
+            "updated": updated or None,
+        },
+    }
+
+
+def normalize_csv(infile: Path, field_map: dict[str, Any]) -> dict[str, Any]:
+    with infile.open("r", encoding="utf-8", newline="") as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+
+    if not rows:
+        raise ValueError("CSV is empty and contains no Jira issues.")
+
+    canonical = field_map["canonical_fields"]
+    first_row = rows[0]
+    resolved_columns = {name: find_column(first_row, aliases) for name, aliases in canonical.items()}
+
+    missing_required = [name for name in field_map.get("required_canonical_fields", []) if not resolved_columns.get(name)]
+    if missing_required:
+        recommendations = ", ".join(field_map.get("recommended_jira_export_columns", []))
+        missing_cols = ", ".join(missing_required)
+        raise ValueError(
+            f"Missing required Jira CSV canonical fields: {missing_cols}. "
+            f"Include equivalent Jira export columns. Recommended columns: {recommendations}"
+        )
+
+    issues = [normalize_issue_from_row(row, field_map, resolved_columns) for row in rows]
+    issues = [issue for issue in issues if issue.get("key")]
+    issues = sorted(issues, key=lambda i: i.get("key", ""))
+
+    return {
+        "generated_at": dt.datetime.utcnow().isoformat() + "Z",
+        "source": {
+            "type": "jira_csv_export",
+            "input_path": infile.as_posix(),
+            "field_map": "tools/jira_field_map.json",
+            "resolved_columns": resolved_columns,
+        },
+        "issues": issues,
+    }
+
+
+def normalize_json(infile: Path) -> dict[str, Any]:
+    doc = load_json(infile)
+    if isinstance(doc, dict) and "issues" in doc and isinstance(doc["issues"], list):
+        issues = doc["issues"]
+    elif isinstance(doc, list):
+        issues = doc
+    else:
+        raise ValueError("Unsupported Jira JSON format. Expected object with issues[] or list of issues.")
+
+    normalized = []
+    for issue in issues:
+        key = issue.get("key")
+        fields = issue.get("fields", {})
+        if not key:
+            continue
+        normalized.append({"key": key, "fields": fields})
+
+    normalized.sort(key=lambda i: i.get("key", ""))
+
+    source = doc.get("source") if isinstance(doc, dict) else None
+    return {
+        "generated_at": dt.datetime.utcnow().isoformat() + "Z",
+        "source": {
+            "type": "jira_json",
+            "input_path": infile.as_posix(),
+            "upstream_source": source,
+        },
+        "issues": normalized,
+    }
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--in", dest="infile", required=True, help="inputs/jira_export.csv OR inputs/jira_snapshot.json")
+    ap.add_argument("--field-map", default="tools/jira_field_map.json")
+    ap.add_argument("--out", default="inputs/jira_snapshot.json")
+    args = ap.parse_args()
+
+    infile = Path(args.infile)
+    if not infile.exists():
+        raise SystemExit(f"Input file not found: {infile}")
+
+    field_map = load_field_map(args.field_map)
+
+    try:
+        suffix = infile.suffix.lower()
+        if suffix == ".csv":
+            normalized = normalize_csv(infile, field_map)
+        elif suffix == ".json":
+            normalized = normalize_json(infile)
+        else:
+            raise ValueError("Unsupported input type. Use a .csv Jira export or .json Jira snapshot.")
+    except ValueError as exc:
+        raise SystemExit(f"Ingestion failed: {exc}") from exc
+
+    dump_json(args.out, normalized)
+    print(f"Wrote normalized Jira snapshot with {len(normalized['issues'])} issues to {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/jira_field_map.json
+++ b/tools/jira_field_map.json
@@ -1,0 +1,75 @@
+{
+  "canonical_fields": {
+    "key": [
+      "Issue key",
+      "Key",
+      "Issue Key"
+    ],
+    "summary": [
+      "Summary",
+      "Issue summary",
+      "Title"
+    ],
+    "description": [
+      "Description",
+      "Issue details"
+    ],
+    "issue_type": [
+      "Issue Type",
+      "Type",
+      "Issue type"
+    ],
+    "parent": [
+      "Parent",
+      "Parent key",
+      "Epic Link",
+      "Epic Link (Legacy)",
+      "Epic"
+    ],
+    "components": [
+      "Component/s",
+      "Components",
+      "Component"
+    ],
+    "fixVersions": [
+      "Fix Version/s",
+      "Fix versions",
+      "Fix Version"
+    ],
+    "labels": [
+      "Labels",
+      "Label"
+    ],
+    "status": [
+      "Status"
+    ],
+    "created": [
+      "Created",
+      "Created date"
+    ],
+    "updated": [
+      "Updated",
+      "Updated date"
+    ]
+  },
+  "required_canonical_fields": [
+    "key"
+  ],
+  "multi_value_delimiters": [
+    ",",
+    ";"
+  ],
+  "recommended_jira_export_columns": [
+    "Issue key",
+    "Summary",
+    "Description",
+    "Issue Type",
+    "Parent or Epic Link",
+    "Component/s",
+    "Fix Version/s",
+    "Labels",
+    "Status",
+    "Created",
+    "Updated"
+  ]
+}

--- a/tools/jira_to_change_ledger.py
+++ b/tools/jira_to_change_ledger.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+from typing import Any
+
+from common import load_json, write_jsonl
+
+RENAME_RE = re.compile(r"rename\s+['\"]([^'\"]+)['\"]\s+to\s+['\"]([^'\"]+)['\"]", re.IGNORECASE)
+
+
+CHANGE_TYPES = [
+    "label rename",
+    "workflow change",
+    "new field",
+    "navigation change",
+    "permissions",
+    "other",
+]
+
+
+def choose_change_type(summary: str, description: str) -> str:
+    txt = f"{summary} {description}".lower()
+    if "rename" in txt or "label" in txt:
+        return "label rename"
+    if "workflow" in txt or "step" in txt:
+        return "workflow change"
+    if "field" in txt:
+        return "new field"
+    if "menu" in txt or "navigation" in txt:
+        return "navigation change"
+    if "permission" in txt or "role" in txt:
+        return "permissions"
+    return "other"
+
+
+def flatten_description(desc: Any) -> str:
+    if isinstance(desc, str):
+        return desc
+    if isinstance(desc, dict):
+        out: list[str] = []
+        for item in desc.get("content", []):
+            out.extend(flatten_description(item).split("\n"))
+        if desc.get("text"):
+            out.append(str(desc["text"]))
+        return "\n".join([x for x in out if x])
+    if isinstance(desc, list):
+        return "\n".join(flatten_description(x) for x in desc)
+    return ""
+
+
+def detect_ui_text_changes(summary: str, description: str) -> list[dict[str, Any]]:
+    combined = f"{summary}\n{description}"
+    matches = list(RENAME_RE.finditer(combined))
+    out = []
+    for m in matches:
+        out.append({"old_label": m.group(1).strip(), "new_label": m.group(2).strip(), "context": "jira_text"})
+    return out
+
+
+def split_records(issue: dict[str, Any]) -> list[dict[str, Any]]:
+    fields = issue.get("fields", {})
+    key = issue.get("key", "UNKNOWN")
+    summary = fields.get("summary") or ""
+    description = flatten_description(fields.get("description"))
+    release = None
+    fix_versions = fields.get("fixVersions") or []
+    if fix_versions:
+        release = fix_versions[0].get("name")
+
+    ui_changes = detect_ui_text_changes(summary, description)
+    if not ui_changes:
+        ui_changes = [{"old_label": None, "new_label": None, "context": "not_detected"}]
+
+    records = []
+    for idx, ui in enumerate(ui_changes, start=1):
+        ctype = choose_change_type(summary, description)
+        reason = "Detected explicit rename pattern" if ui.get("old_label") else "Insufficient structured UI details in Jira fields"
+        rec = {
+            "change_id": f"{key}-{idx}" if len(ui_changes) > 1 else key,
+            "source": "jira",
+            "release": release,
+            "feature_area": (fields.get("components") or [{}])[0].get("name") if fields.get("components") else None,
+            "user_visible_summary": summary[:280],
+            "change_type": ctype,
+            "ui_text_changes": [ui] if ui else [],
+            "workflow_before": None,
+            "workflow_after": None,
+            "evidence": {
+                "jira_key": key,
+                "links": [],
+                "fields_used": ["summary", "description", "components", "fixVersions"],
+            },
+            "docs_relevance_score": 0.9 if ctype in {"label rename", "workflow change", "navigation change"} else 0.6,
+            "docs_relevance_reason": reason,
+        }
+        records.append(rec)
+    return records
+
+
+def validate_record(rec: dict[str, Any]) -> None:
+    required = [
+        "change_id",
+        "source",
+        "user_visible_summary",
+        "change_type",
+        "ui_text_changes",
+        "evidence",
+        "docs_relevance_score",
+        "docs_relevance_reason",
+    ]
+    for r in required:
+        if r not in rec:
+            raise ValueError(f"missing required field: {r}")
+    if rec["change_type"] not in CHANGE_TYPES:
+        raise ValueError(f"invalid change_type: {rec['change_type']}")
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--in", dest="infile", default="inputs/jira_snapshot.json")
+    ap.add_argument("--out", default="artifacts/docs_change_ledger.jsonl")
+    ap.add_argument("--min-docs-score", type=float, default=0.0)
+    args = ap.parse_args()
+
+    snapshot = load_json(args.infile)
+    issues = snapshot.get("issues", [])
+
+    records: list[dict[str, Any]] = []
+    for issue in issues:
+        split = split_records(issue)
+        for rec in split:
+            validate_record(rec)
+            if rec["docs_relevance_score"] >= args.min_docs_score:
+                records.append(rec)
+
+    records = sorted(records, key=lambda r: r["change_id"])
+    write_jsonl(args.out, records)
+    print(f"Wrote {len(records)} change ledger records to {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/load_change_ledger.py
+++ b/tools/load_change_ledger.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+from common import write_jsonl
+
+JIRA_KEY_RE = re.compile(r"\b([A-Z][A-Z0-9]+-\d+)\b")
+
+
+def make_record(change_id: str, summary: str, source: str, release: str | None = None) -> dict[str, Any]:
+    return {
+        "change_id": change_id,
+        "source": source,
+        "release": release,
+        "feature_area": None,
+        "user_visible_summary": summary,
+        "change_type": "other",
+        "ui_text_changes": [],
+        "workflow_before": None,
+        "workflow_after": None,
+        "evidence": {"jira_key": change_id if "-" in change_id else None, "links": [], "fields_used": ["input"]},
+        "docs_relevance_score": 0.5,
+        "docs_relevance_reason": "Loaded from generic input; needs triage.",
+    }
+
+
+def parse_markdown(path: Path) -> list[dict[str, Any]]:
+    records = []
+    idx = 0
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if not line.strip().startswith(("-", "*")):
+            continue
+        idx += 1
+        key_match = JIRA_KEY_RE.search(line)
+        key = key_match.group(1) if key_match else f"MD-{idx}"
+        summary = re.sub(r"^[\-*]\s*", "", line).strip()
+        records.append(make_record(key, summary, "markdown"))
+    return records
+
+
+def parse_jira_json(path: Path) -> list[dict[str, Any]]:
+    doc = json.loads(path.read_text(encoding="utf-8"))
+    issues = doc.get("issues", doc if isinstance(doc, list) else [])
+    records = []
+    for issue in issues:
+        key = issue.get("key", "UNKNOWN")
+        fields = issue.get("fields", {})
+        summary = fields.get("summary", "")
+        release = (fields.get("fixVersions") or [{}])[0].get("name") if fields.get("fixVersions") else None
+        records.append(make_record(key, summary, "jira_json", release=release))
+    return records
+
+
+def parse_jira_csv(path: Path) -> list[dict[str, Any]]:
+    records = []
+    with path.open("r", encoding="utf-8", newline="") as f:
+        reader = csv.DictReader(f)
+        for i, row in enumerate(reader, start=1):
+            key = row.get("Issue key") or row.get("Key") or f"CSV-{i}"
+            summary = row.get("Summary") or row.get("Issue summary") or ""
+            release = row.get("Fix versions") or row.get("Fix Version/s")
+            records.append(make_record(key, summary, "jira_csv", release=release))
+    return records
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--in", dest="infile", required=True)
+    ap.add_argument("--type", choices=["markdown", "jira_json", "jira_csv"], required=True)
+    ap.add_argument("--out", default="artifacts/docs_change_ledger.jsonl")
+    args = ap.parse_args()
+
+    path = Path(args.infile)
+    if args.type == "markdown":
+        records = parse_markdown(path)
+    elif args.type == "jira_json":
+        records = parse_jira_json(path)
+    else:
+        records = parse_jira_csv(path)
+
+    write_jsonl(args.out, records)
+    print(f"Wrote {len(records)} records to {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/pull_from_jira.py
+++ b/tools/pull_from_jira.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+DEFAULT_FIELDS = [
+    "summary",
+    "issuetype",
+    "status",
+    "project",
+    "components",
+    "labels",
+    "fixVersions",
+    "parent",
+    "subtasks",
+    "description",
+    "updated",
+]
+
+
+def build_jql(base_jql: str | None, since: str | None, release: str | None) -> str:
+    parts = []
+    if base_jql:
+        parts.append(f"({base_jql})")
+    if since:
+        dt.date.fromisoformat(since)
+        parts.append(f"updated >= '{since}'")
+    if release:
+        release_q = release.replace("'", "\\'")
+        parts.append(f"fixVersion = '{release_q}'")
+    return " AND ".join(parts) if parts else "ORDER BY updated DESC"
+
+
+def jira_auth_headers() -> tuple[str, dict[str, str]]:
+    base_url = os.getenv("JIRA_BASE_URL", "").rstrip("/")
+    user = os.getenv("JIRA_USER_EMAIL") or os.getenv("JIRA_USERNAME")
+    token = os.getenv("JIRA_API_TOKEN") or os.getenv("JIRA_PAT")
+    version = os.getenv("JIRA_API_VERSION", "auto")
+
+    if not (base_url and user and token):
+        print(
+            "Missing Jira credentials. Set JIRA_BASE_URL, JIRA_USER_EMAIL (or JIRA_USERNAME), and JIRA_API_TOKEN (or JIRA_PAT).",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    import base64
+
+    auth = base64.b64encode(f"{user}:{token}".encode("utf-8")).decode("ascii")
+    if version == "auto":
+        api_versions = ["3", "2"]
+    else:
+        api_versions = [str(version)]
+
+    headers = {
+        "Authorization": f"Basic {auth}",
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+    }
+    return base_url, {"api_versions": json.dumps(api_versions), **headers}
+
+
+def request_with_retry(url: str, payload: dict[str, Any], headers: dict[str, str], retries: int = 4) -> dict[str, Any]:
+    body = json.dumps(payload).encode("utf-8")
+    for i in range(retries + 1):
+        try:
+            req = urllib.request.Request(url, data=body, headers=headers, method="POST")
+            with urllib.request.urlopen(req, timeout=60) as resp:
+                return json.loads(resp.read().decode("utf-8"))
+        except urllib.error.HTTPError as e:
+            if e.code in (429, 500, 502, 503, 504) and i < retries:
+                delay = (2**i) + 0.2
+                time.sleep(delay)
+                continue
+            detail = e.read().decode("utf-8", errors="ignore")
+            raise RuntimeError(f"Jira request failed ({e.code}): {detail}") from e
+        except urllib.error.URLError as e:
+            if i < retries:
+                time.sleep((2**i) + 0.2)
+                continue
+            raise RuntimeError(f"Jira URL error: {e}") from e
+    raise RuntimeError("Jira request exhausted retries")
+
+
+def fetch_issues(base_url: str, versions: list[str], headers: dict[str, str], jql: str, max_issues: int | None, fields: list[str]) -> dict[str, Any]:
+    for version in versions:
+        start_at = 0
+        page_size = 50
+        all_issues: list[dict[str, Any]] = []
+        try:
+            while True:
+                if max_issues:
+                    remaining = max_issues - len(all_issues)
+                    if remaining <= 0:
+                        break
+                    page_size = min(page_size, remaining)
+
+                payload = {
+                    "jql": jql,
+                    "startAt": start_at,
+                    "maxResults": page_size,
+                    "fields": fields,
+                }
+                url = f"{base_url}/rest/api/{version}/search"
+                data = request_with_retry(url, payload, headers)
+                issues = data.get("issues", [])
+                total = int(data.get("total", 0))
+                all_issues.extend(issues)
+                start_at += len(issues)
+                if not issues or start_at >= total:
+                    break
+            return {"api_version": version, "issues": all_issues}
+        except RuntimeError as e:
+            if version == versions[-1]:
+                raise
+            print(f"API /rest/api/{version} failed ({e}); trying next configured version", file=sys.stderr)
+    raise RuntimeError("Unable to fetch from Jira")
+
+
+def expand_epics(issues: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    by_key = {i.get("key"): i for i in issues}
+    expanded = list(issues)
+    for issue in issues:
+        fields = issue.get("fields", {})
+        parent = fields.get("parent") or {}
+        parent_key = parent.get("key")
+        if parent_key and parent_key in by_key:
+            continue
+        subtasks = fields.get("subtasks") or []
+        for st in subtasks:
+            st_key = st.get("key")
+            if st_key and st_key in by_key:
+                continue
+    return expanded
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--jql")
+    ap.add_argument("--since")
+    ap.add_argument("--release")
+    ap.add_argument("--max-issues", type=int)
+    ap.add_argument("--out", default="inputs/jira_snapshot.json")
+    ap.add_argument("--include-comments", action="store_true")
+    ap.add_argument("--include-attachments", action="store_true")
+    ap.add_argument("--dry-run", action="store_true")
+    args = ap.parse_args()
+
+    base_url, headers = jira_auth_headers()
+    versions = json.loads(headers.pop("api_versions"))
+
+    fields = DEFAULT_FIELDS.copy()
+    if args.include_comments:
+        fields.append("comment")
+    if args.include_attachments:
+        fields.append("attachment")
+
+    resolved_jql = build_jql(args.jql, args.since, args.release)
+    if args.dry_run:
+        print(json.dumps({"resolved_jql": resolved_jql, "max_issues": args.max_issues, "fields": fields}, indent=2))
+        return
+
+    fetched = fetch_issues(base_url, versions, headers, resolved_jql, args.max_issues, fields)
+    issues = expand_epics(fetched["issues"])
+    snapshot = {
+        "generated_at": dt.datetime.utcnow().isoformat() + "Z",
+        "source": {
+            "jira_base_url": base_url,
+            "jql": resolved_jql,
+            "api_version": fetched["api_version"],
+            "fields": fields,
+            "max_issues": args.max_issues,
+        },
+        "issues": issues,
+    }
+
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(snapshot, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    print(f"Wrote {len(issues)} issues to {out}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation
- Accept Jira CSV exports (in addition to API JSON) so the docs pipeline can run without live Jira access and teams that only provide CSVs are supported.
- Normalize CSV or JSON inputs into a single stable internal snapshot format (`inputs/jira_snapshot.json`) so downstream steps (changelog → ledger → queue → apply) remain unchanged and deterministic.
- Provide configurable column-to-field mapping and clear validation so missing required columns (notably issue key) fail with actionable guidance.

### Description
- Add `tools/ingest_jira_export.py` which accepts `--in` as a Jira CSV export or JSON snapshot and writes a normalized snapshot with `issues[]`, stable sorting, and `source` metadata; it splits multi-value columns, maps CSV columns to canonical fields, and emits clear errors on invalid input.
- Add `tools/jira_field_map.json` containing canonical field aliases, required canonical fields, multi-value delimiters, and recommended Jira export columns used for validation and resolution of CSV headers.
- Add a sanitized sample CSV at `inputs/sample_jira_export.csv` and ensure the demo snapshot contract `inputs/jira_snapshot.json` can be produced from it.
- Update `docs-automation/README.md` and `.agents/skills/training-updater/SKILL.md` to document the new normalization step and include the `ingest_jira_export.py` usage in the demo flow and command list.
- Improve user-facing failure behavior in the new ingest tool to wrap validation errors with a clear `Ingestion failed:` message.

### Testing
- Ran `python -m py_compile tools/*.py` and it succeeded.
- Ran `python tools/ingest_jira_export.py --in inputs/sample_jira_export.csv --out inputs/jira_snapshot.json` and it wrote a normalized snapshot with 3 issues (succeeds).
- Ran ingestion on a malformed CSV (`/tmp/bad_jira_export.csv`) and verified it exits nonzero with the clear missing-field message (succeeds as expected).
- Executed the demo end-to-end from CSV through downstream steps: `python tools/generate_changelog_from_jira.py`, `python tools/jira_to_change_ledger.py`, `python tools/build_lesson_manifest.py --limit 3`, `python tools/generate_update_queue.py`, and `python tools/apply_update_queue.py --limit 1`, and all steps completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6995e5d403d08326abab71987ea3a955)